### PR TITLE
prefer-power-assert rule

### DIFF
--- a/docs/rules/prefer-power-assert.md
+++ b/docs/rules/prefer-power-assert.md
@@ -1,0 +1,33 @@
+# Only allow use of the assertions that have no power-assert alternative
+
+- `t.ok()` __(You can do most things with this one)__
+- `t.same()`
+- `t.notSame()`
+- `t.throws()`
+- `t.notThrows()`
+- `t.pass()`
+- `t.fail()`
+
+Useful for people wanting to fully embrace the power of power-assert.
+
+
+## Fail
+
+```js
+import test from 'ava';
+
+test(t => {
+	t.is(foo, bar);
+});
+```
+
+
+## Pass
+
+```js
+import test from 'ava';
+
+test(t => {
+	t.ok(foo === bar);
+});
+```

--- a/docs/rules/prefer-power-assert.md
+++ b/docs/rules/prefer-power-assert.md
@@ -1,14 +1,14 @@
-# Only allow use of the assertions that have no power-assert alternative
+# Allow only use of the asserts that have no power-assert alternative.
 
-- `t.ok()` __(You can do most things with this one)__
-- `t.same()`
-- `t.notSame()`
-- `t.throws()`
-- `t.notThrows()`
-- `t.pass()`
-- `t.fail()`
+- [`t.ok()`](https://github.com/sindresorhus/ava#okvalue-message) __(You can do [most things](https://github.com/sindresorhus/ava#enhanced-asserts) with this one)__
+- [`t.same()`](https://github.com/sindresorhus/ava#samevalue-expected-message)
+- [`t.notSame()`](https://github.com/sindresorhus/ava#notsamevalue-expected-message)
+- [`t.throws()`](https://github.com/sindresorhus/ava#throwsfunctionpromise-error-message)
+- [`t.notThrows()`](https://github.com/sindresorhus/ava#notthrowsfunctionpromise-message)
+- [`t.pass()`](https://github.com/sindresorhus/ava#passmessage)
+- [`t.fail()`](https://github.com/sindresorhus/ava#failmessage)
 
-Useful for people wanting to fully embrace the power of power-assert.
+Useful for people wanting to fully embrace the power of [power-assert](https://github.com/power-assert-js/power-assert).
 
 
 ## Fail

--- a/index.js
+++ b/index.js
@@ -2,9 +2,11 @@
 
 module.exports = {
 	rules: {
+		'prefer-power-assert': require('./rules/prefer-power-assert'),
 		'test-ended': require('./rules/test-ended')
 	},
 	rulesConfig: {
+		'prefer-power-assert': 0,
 		'test-ended': 0
 	}
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
     "test",
     "runner"
   ],
+  "dependencies": {
+    "deep-strict-equal": "^0.1.0",
+    "espurify": "^1.5.0"
+  },
   "devDependencies": {
     "ava": "*",
     "eslint": "^1.10.3",
@@ -47,9 +51,5 @@
   },
   "peerDependencies": {
     "eslint": ">=1.10.0"
-  },
-  "dependencies": {
-    "deep-strict-equal": "^0.1.0",
-    "espurify": "^1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "ava": "*",
     "eslint": "^1.10.3",
+    "js-combinatorics": "^0.5.0",
     "xo": "*"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
   },
   "peerDependencies": {
     "eslint": ">=1.10.0"
+  },
+  "dependencies": {
+    "deep-strict-equal": "^0.1.0",
+    "espurify": "^1.5.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Configure it in package.json.
 The rules will only activate in test files.
 
 - [test-ended](docs/rules/test-ended.md) - Ensure callback tests are explicitly ended.
-- [prefer-power-assert](docs/rules/prefer-power-assert.md) - Only allow use of the assertions that have no power-assert alternative.
+- [prefer-power-assert](docs/rules/prefer-power-assert.md) - Allow only use of the asserts that have no [power-assert](https://github.com/power-assert-js/power-assert) alternative.
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ Configure it in package.json.
 			"ava"
 		],
 		"rules": {
+			"ava/prefer-power-assert": 0,
 			"ava/test-ended": 2
 		}
 	}
@@ -34,6 +35,7 @@ Configure it in package.json.
 The rules will only activate in test files.
 
 - [test-ended](docs/rules/test-ended.md) - Ensure callback tests are explicitly ended.
+- [prefer-power-assert](docs/rules/prefer-power-assert.md) - Only allow use of the assertions that have no power-assert alternative.
 
 
 ## License

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -50,22 +50,13 @@ var avaVariableDeclaratorAst = {
 	}
 };
 
-function isTestFunctionCall(callee) {
-	return callee.type === 'Identifier' &&
-		callee.name === 'test';
-}
-
-function isTestFunctionCallWithSingleModifier(callee) {
-	return callee.type === 'MemberExpression' &&
-		callee.object.type === 'Identifier' &&
-		callee.object.name === 'test';
-}
-
-function isTestFunctionCallWithDoubleModifiers(callee) {
-	return callee.type === 'MemberExpression' &&
-		callee.object.type === 'MemberExpression' &&
-		callee.object.object.type === 'Identifier' &&
-		callee.object.object.name === 'test';
+function isTestFunctionCall(node) {
+	if (node.type === 'Identifier') {
+		return node.name === 'test';
+	} else if (node.type === 'MemberExpression') {
+		return isTestFunctionCall(node.object);
+	}
+	return false;
 }
 
 function assertionCalleeAst(methodName) {
@@ -136,9 +127,7 @@ module.exports = function (context) {
 			var callee = espurify(node.callee);
 
 			if (!currentTestNode) {
-				if (isTestFunctionCall(callee) ||
-					isTestFunctionCallWithSingleModifier(callee) ||
-					isTestFunctionCallWithDoubleModifiers(callee)) {
+				if (isTestFunctionCall(callee)) {
 					// entering test function
 					currentTestNode = node;
 				}

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -142,8 +142,6 @@ module.exports = function (context) {
 					// entering test function
 					currentTestNode = node;
 				}
-			}
-			if (!currentTestNode) {
 				// not in test function
 				return;
 			}
@@ -151,7 +149,7 @@ module.exports = function (context) {
 			if (callee.type === 'MemberExpression') {
 				notAllowed.forEach(function (methodName) {
 					if (isCalleeMatched(callee, methodName)) {
-						context.report(node, 'Only allow use of the assertions that have no power-assert alternative.');
+						context.report(node, 'Only asserts with no power-assert alternative are allowed.');
 					}
 				});
 			}

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -1,0 +1,52 @@
+'use strict';
+var util = require('../util');
+/* eslint quote-props: [2, "as-needed"] */
+
+var notAllowed = [
+	'notOk',
+	'true',
+	'false',
+	'is',
+	'not',
+	'regex',
+	'ifError'
+];
+
+module.exports = function (context) {
+	var isTestFile = false;
+	var currentTestNode = false;
+
+	return {
+		CallExpression: function (node) {
+			var callee = node.callee;
+
+			if (util.isTestFile(node)) {
+				isTestFile = true;
+			}
+			if (!isTestFile) {
+				return;
+			}
+
+			if (callee.type === 'Identifier' && callee.name === 'test') {
+				currentTestNode = node;
+			} else if (callee.type === 'MemberExpression' && callee.object.type === 'Identifier' && callee.object.name === 'test') {
+				currentTestNode = node;
+			}
+			if (!currentTestNode) {
+				return;
+			}
+
+			if (callee.type === 'MemberExpression' && callee.object.type === 'Identifier' && callee.object.name === 't') {
+				if (notAllowed.indexOf(callee.property.name) !== -1) {
+					context.report(node, 'Only allow use of the assertions that have no power-assert alternative.');
+				}
+			}
+		},
+		'CallExpression:exit': function (node) {
+			if (currentTestNode === node) {
+				currentTestNode = null;
+				return;
+			}
+		}
+	};
+};

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -94,18 +94,18 @@ function isCalleeMatched(callee, methodName) {
 /* eslint quote-props: [2, "as-needed"] */
 module.exports = function (context) {
 	var isTestFile = false;
-	var currentTestNode = false;
+	var currentTestNode = null;
 
 	return {
 		ImportDeclaration: function (node) {
-			if (deepStrictEqual(espurify(node), moduleAst)) {
+			if (!isTestFile && deepStrictEqual(espurify(node), moduleAst)) {
 				isTestFile = true;
 			}
 		},
 		CallExpression: function (node) {
 			var callee = espurify(node.callee);
 
-			if (util.isTestFile(node)) {
+			if (!isTestFile && util.isTestFile(node)) {
 				isTestFile = true;
 			}
 			if (!isTestFile) {

--- a/test/prefer-power-assert.js
+++ b/test/prefer-power-assert.js
@@ -40,7 +40,7 @@ const notAllowedMethods = [
 	'regex(str, re)',
 	'ifError(err)'
 ];
-for (let methodName of notAllowedMethods) {
+for (const methodName of notAllowedMethods) {
 	testNotAllowedMethod(methodName);
 }
 
@@ -67,7 +67,7 @@ const allowedMethods = [
 	'throws(block)',
 	'notThrows(block)'
 ];
-for (let methodName of allowedMethods) {
+for (const methodName of allowedMethods) {
 	testAllowedMethod(methodName);
 }
 
@@ -88,8 +88,8 @@ function testWithModifier(modifier) {
 		});
 	});
 }
-for (let mod1 of ['skip', 'only']) {
-	for (let mod2 of ['cb', 'serial']) {
+for (const mod1 of ['skip', 'only']) {
+	for (const mod2 of ['cb', 'serial']) {
 		testWithModifier(mod1);
 		testWithModifier(mod2);
 		testWithModifier(`${mod1}.${mod2}`);
@@ -114,7 +114,7 @@ function testDeclaration(declaration) {
 		});
 	});
 }
-for (let declaration of [
+for (const declaration of [
 	`var test = require('ava');`,
 	`let test = require('ava');`,
 	`const test = require('ava');`,

--- a/test/prefer-power-assert.js
+++ b/test/prefer-power-assert.js
@@ -17,47 +17,47 @@ const moduleHeader = `import test from 'ava';\n`;
 
 /* eslint no-loop-func: 1 */
 for (let header of [requireHeader, moduleHeader]) {
+	const validCase = (assertion) => {
+		return `${header} test(t => { ${assertion}; });`;
+	};
+	const invalidCase = (assertion) => {
+		return {
+			code: `${header} test(t => { ${assertion}; });`,
+			errors
+		};
+	};
 	test(`with header ${header}`, () => {
 		ruleTester.run('prefer-power-assert', rule, {
 			valid: [
-				header + 'test(t => { t.ok(foo); });',
-				header + 'test(t => { t.same(foo, bar); });',
-				header + 'test(t => { t.notSame(foo, bar); });',
-				header + 'test(t => { t.throws(block); });',
-				header + 'test(t => { t.notThrows(block); });',
+				validCase('t.ok(foo)'),
+				validCase('t.same(foo, bar)'),
+				validCase('t.notSame(foo, bar)'),
+				validCase('t.throws(block)'),
+				validCase('t.notThrows(block)'),
+				validCase('t.skip.ok(foo)'),
+				validCase('t.skip.same(foo, bar)'),
+				validCase('t.skip.notSame(foo, bar)'),
+				validCase('t.skip.throws(block)'),
+				validCase('t.skip.notThrows(block)'),
 				header + 'test.cb(function (t) { t.ok(foo); t.end(); });',
 				// shouldn't be triggered since it's not a test file
 				'test(t => {});'
 			],
 			invalid: [
-				{
-					code: header + 'test(t => { t.notOk(foo); });',
-					errors
-				},
-				{
-					code: header + 'test(t => { t.true(foo); });',
-					errors
-				},
-				{
-					code: header + 'test(t => { t.false(foo); });',
-					errors
-				},
-				{
-					code: header + 'test(t => { t.is(foo, bar); });',
-					errors
-				},
-				{
-					code: header + 'test(t => { t.not(foo, bar); });',
-					errors
-				},
-				{
-					code: header + 'test(t => { t.regex(str, re); });',
-					errors
-				},
-				{
-					code: header + 'test(t => { t.ifError(err); });',
-					errors
-				}
+				invalidCase('t.notOk(foo)'),
+				invalidCase('t.true(foo)'),
+				invalidCase('t.false(foo)'),
+				invalidCase('t.is(foo, bar)'),
+				invalidCase('t.not(foo, bar)'),
+				invalidCase('t.regex(str, re)'),
+				invalidCase('t.ifError(err)'),
+				invalidCase('t.skip.notOk(foo)'),
+				invalidCase('t.skip.true(foo)'),
+				invalidCase('t.skip.false(foo)'),
+				invalidCase('t.skip.is(foo, bar)'),
+				invalidCase('t.skip.not(foo, bar)'),
+				invalidCase('t.skip.regex(str, re)'),
+				invalidCase('t.skip.ifError(err)')
 			]
 		});
 	});

--- a/test/prefer-power-assert.js
+++ b/test/prefer-power-assert.js
@@ -1,0 +1,57 @@
+import test from 'ava';
+import {RuleTester} from 'eslint';
+import rule from '../rules/prefer-power-assert';
+
+const ruleTester = new RuleTester({
+	env: {
+		es6: true
+	}
+});
+
+const errors = [{ruleId: 'prefer-power-assert'}];
+const header = `const test = require('ava');\n`;
+
+test(() => {
+	ruleTester.run('prefer-power-assert', rule, {
+		valid: [
+			header + 'test(t => { t.ok(foo); });',
+			header + 'test(t => { t.same(foo, bar); });',
+			header + 'test(t => { t.notSame(foo, bar); });',
+			header + 'test(t => { t.throws(block); });',
+			header + 'test(t => { t.notThrows(block); });',
+			header + 'test.cb(function (t) { t.ok(foo); t.end(); });',
+			// shouldn't be triggered since it's not a test file
+			'test(t => {});'
+		],
+		invalid: [
+			{
+				code: header + 'test(t => { t.notOk(foo); });',
+				errors
+			},
+			{
+				code: header + 'test(t => { t.true(foo); });',
+				errors
+			},
+			{
+				code: header + 'test(t => { t.false(foo); });',
+				errors
+			},
+			{
+				code: header + 'test(t => { t.is(foo, bar); });',
+				errors
+			},
+			{
+				code: header + 'test(t => { t.not(foo, bar); });',
+				errors
+			},
+			{
+				code: header + 'test(t => { t.regex(str, re); });',
+				errors
+			},
+			{
+				code: header + 'test(t => { t.ifError(err); });',
+				errors
+			}
+		]
+	});
+});

--- a/test/prefer-power-assert.js
+++ b/test/prefer-power-assert.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import {RuleTester} from 'eslint';
 import rule from '../rules/prefer-power-assert';
+import {permutationCombination} from 'js-combinatorics';
 
 const ruleTester = new RuleTester({
 	env: {
@@ -88,13 +89,8 @@ function testWithModifier(modifier) {
 		});
 	});
 }
-for (const mod1 of ['skip', 'only']) {
-	for (const mod2 of ['cb', 'serial']) {
-		testWithModifier(mod1);
-		testWithModifier(mod2);
-		testWithModifier(`${mod1}.${mod2}`);
-		testWithModifier(`${mod2}.${mod1}`);
-	}
+for (const modifiers of permutationCombination(['skip', 'only', 'cb', 'serial']).toArray()) {
+	testWithModifier(modifiers.join('.'));
 }
 
 function testDeclaration(declaration) {

--- a/test/prefer-power-assert.js
+++ b/test/prefer-power-assert.js
@@ -62,3 +62,27 @@ for (let header of [requireHeader, moduleHeader]) {
 		});
 	});
 }
+
+function testWithModifier(modifier) {
+	test(`with modifier test.${modifier}`, () => {
+		ruleTester.run('prefer-power-assert', rule, {
+			valid: [
+				`import test from 'ava';\n test.${modifier}(t => { t.ok(foo); });`
+			],
+			invalid: [
+				{
+					code: `import test from 'ava';\n test.${modifier}(t => { t.notOk(foo); });`,
+					errors
+				}
+			]
+		});
+	});
+}
+for (let mod1 of ['skip', 'only']) {
+	for (let mod2 of ['cb', 'serial']) {
+		testWithModifier(mod1);
+		testWithModifier(mod2);
+		testWithModifier(`${mod1}.${mod2}`);
+		testWithModifier(`${mod2}.${mod1}`);
+	}
+}

--- a/test/prefer-power-assert.js
+++ b/test/prefer-power-assert.js
@@ -5,53 +5,60 @@ import rule from '../rules/prefer-power-assert';
 const ruleTester = new RuleTester({
 	env: {
 		es6: true
+	},
+	ecmaFeatures: {
+		modules: true
 	}
 });
 
 const errors = [{ruleId: 'prefer-power-assert'}];
-const header = `const test = require('ava');\n`;
+const requireHeader = `const test = require('ava');\n`;
+const moduleHeader = `import test from 'ava';\n`;
 
-test(() => {
-	ruleTester.run('prefer-power-assert', rule, {
-		valid: [
-			header + 'test(t => { t.ok(foo); });',
-			header + 'test(t => { t.same(foo, bar); });',
-			header + 'test(t => { t.notSame(foo, bar); });',
-			header + 'test(t => { t.throws(block); });',
-			header + 'test(t => { t.notThrows(block); });',
-			header + 'test.cb(function (t) { t.ok(foo); t.end(); });',
-			// shouldn't be triggered since it's not a test file
-			'test(t => {});'
-		],
-		invalid: [
-			{
-				code: header + 'test(t => { t.notOk(foo); });',
-				errors
-			},
-			{
-				code: header + 'test(t => { t.true(foo); });',
-				errors
-			},
-			{
-				code: header + 'test(t => { t.false(foo); });',
-				errors
-			},
-			{
-				code: header + 'test(t => { t.is(foo, bar); });',
-				errors
-			},
-			{
-				code: header + 'test(t => { t.not(foo, bar); });',
-				errors
-			},
-			{
-				code: header + 'test(t => { t.regex(str, re); });',
-				errors
-			},
-			{
-				code: header + 'test(t => { t.ifError(err); });',
-				errors
-			}
-		]
+/* eslint no-loop-func: 1 */
+for (let header of [requireHeader, moduleHeader]) {
+	test(`with header ${header}`, () => {
+		ruleTester.run('prefer-power-assert', rule, {
+			valid: [
+				header + 'test(t => { t.ok(foo); });',
+				header + 'test(t => { t.same(foo, bar); });',
+				header + 'test(t => { t.notSame(foo, bar); });',
+				header + 'test(t => { t.throws(block); });',
+				header + 'test(t => { t.notThrows(block); });',
+				header + 'test.cb(function (t) { t.ok(foo); t.end(); });',
+				// shouldn't be triggered since it's not a test file
+				'test(t => {});'
+			],
+			invalid: [
+				{
+					code: header + 'test(t => { t.notOk(foo); });',
+					errors
+				},
+				{
+					code: header + 'test(t => { t.true(foo); });',
+					errors
+				},
+				{
+					code: header + 'test(t => { t.false(foo); });',
+					errors
+				},
+				{
+					code: header + 'test(t => { t.is(foo, bar); });',
+					errors
+				},
+				{
+					code: header + 'test(t => { t.not(foo, bar); });',
+					errors
+				},
+				{
+					code: header + 'test(t => { t.regex(str, re); });',
+					errors
+				},
+				{
+					code: header + 'test(t => { t.ifError(err); });',
+					errors
+				}
+			]
+		});
 	});
-});
+}

--- a/test/prefer-power-assert.js
+++ b/test/prefer-power-assert.js
@@ -123,6 +123,29 @@ for (const declaration of [
 	testDeclaration(declaration);
 }
 
+const assertionInNestedCode = `
+import test from 'ava';
+
+test(t => {
+	const foo = () => {
+		t.is('foo', 'bar');
+	};
+	foo();
+});
+`;
+test('assertion in nested code', () => {
+	ruleTester.run('prefer-power-assert', rule, {
+		valid: [
+		],
+		invalid: [
+			{
+				code: assertionInNestedCode,
+				errors
+			}
+		]
+	});
+});
+
 test(`misc`, () => {
 	ruleTester.run('prefer-power-assert', rule, {
 		valid: [


### PR DESCRIPTION
Only allows use of the assertions that have no power-assert alternative.

fixes #9 


### TODO

- [x] simplest case
- [x] callee chaining detection
```js
test.before.skip([title], testFn);
test.skip.after(....);
test.serial.only(...);
test.only.serial(...);
```

- [x] assertion chaining detection `t.skip.is(foo(), 5);`
- [x] ES2015 modules support `import test from 'ava'`
- [x] initial document (needs help! <= Thanks!)
- [x] apply feedbacks
- provide some utilities for other rules => should be extracted in future PR for other rules
