### PR TITLE
Update to ESLint 2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,19 @@ module.exports = {
 		'prefer-power-assert': require('./rules/prefer-power-assert'),
 		'test-ended': require('./rules/test-ended')
 	},
-	rulesConfig: {
-		'prefer-power-assert': 0,
-		'test-ended': 0
+	configs: {
+		recommended: {
+			env: {
+				es6: true
+			},
+			parserOptions: {
+				ecmaVersion: 6,
+				sourceType: 'module'
+			},
+			rules: {
+				'prefer-power-assert': 0,
+				'test-ended': 2
+			}
+		}
 	}
 };

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
   },
   "devDependencies": {
     "ava": "*",
-    "eslint": "^1.10.3",
+    "eslint": "^2.2.0",
     "js-combinatorics": "^0.5.0",
     "xo": "*"
   },
   "peerDependencies": {
-    "eslint": ">=1.10.0"
+    "eslint": ">=2"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -12,12 +12,19 @@ $ npm install --save-dev eslint eslint-plugin-ava
 
 ## Usage
 
-Configure it in package.json.
+Configure it in `package.json`.
 
 ```json
 {
 	"name": "my-awesome-project",
 	"eslintConfig": {
+		"env": {
+			"es6": true
+		},
+		"parserOptions": {
+			"ecmaVersion": 6,
+			"sourceType": "module"
+		},
 		"plugins": [
 			"ava"
 		],
@@ -36,6 +43,29 @@ The rules will only activate in test files.
 
 - [test-ended](docs/rules/test-ended.md) - Ensure callback tests are explicitly ended.
 - [prefer-power-assert](docs/rules/prefer-power-assert.md) - Allow only use of the asserts that have no [power-assert](https://github.com/power-assert-js/power-assert) alternative.
+
+
+## Recommended configuration
+
+This plugin exports a [`recommended` configuration](index.js#L9) that enforces good practices.
+
+To enable this configuration use the `extends` property in your `package.json`.
+
+```json
+{
+	"name": "my-awesome-project",
+	"eslintConfig": {
+		"extends": "plugin:ava/recommended",
+		"plugins": [
+			"ava"
+		]
+	}
+}
+```
+
+See [ESLint documentation](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information about extending configuration files.
+
+**Note**: This configuration will also enable the correct [parser options](http://eslint.org/docs/user-guide/configuring#specifying-parser-options) and [environment](http://eslint.org/docs/user-guide/configuring#specifying-environments).
 
 
 ## License

--- a/test/prefer-power-assert.js
+++ b/test/prefer-power-assert.js
@@ -7,8 +7,9 @@ const ruleTester = new RuleTester({
 	env: {
 		es6: true
 	},
-	ecmaFeatures: {
-		modules: true
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module'
 	}
 });
 


### PR DESCRIPTION
In the new recommended config I set up some defaults for environment and parser options. I noticed that you can also use `const ava = require('ava')` and not need `sourceType: module`. But all of the examples of AVA use the `import` syntax so I think this should be in the recommended configuration.

Feedback is definitely welcome.

Fixes #4
Fixes #17