### PR TITLE
provide minimal framework for AVA rule developers

### DIFF
--- a/create-ava-rule.js
+++ b/create-ava-rule.js
@@ -1,0 +1,133 @@
+'use strict';
+var espurify = require('espurify');
+var deepStrictEqual = require('deep-strict-equal');
+
+var avaImportDeclarationAst = {
+	type: 'ImportDeclaration',
+	specifiers: [
+		{
+			type: 'ImportDefaultSpecifier',
+			local: {
+				type: 'Identifier',
+				name: 'test'
+			}
+		}
+	],
+	source: {
+		type: 'Literal',
+		value: 'ava'
+	}
+};
+
+var avaVariableDeclaratorAst = {
+	type: 'VariableDeclarator',
+	id: {
+		type: 'Identifier',
+		name: 'test'
+	},
+	init: {
+		type: 'CallExpression',
+		callee: {
+			type: 'Identifier',
+			name: 'require'
+		},
+		arguments: [
+			{
+				type: 'Literal',
+				value: 'ava'
+			}
+		]
+	}
+};
+
+function isTestFunctionCall(node) {
+	if (node.type === 'Identifier') {
+		return node.name === 'test';
+	} else if (node.type === 'MemberExpression') {
+		return isTestFunctionCall(node.object);
+	}
+
+	return false;
+}
+
+function hasTestModifier(node, mod) {
+	if (node.type === 'CallExpression') {
+		return hasTestModifier(node.callee, mod);
+	} else if (node.type === 'MemberExpression') {
+		if (node.property.type === 'Identifier' && node.property.name === mod) {
+			return true;
+		}
+		return hasTestModifier(node.object, mod);
+	}
+	return false;
+}
+
+module.exports = function createAvaRule() {
+	var isTestFile = false;
+	var currentTestNode = null;
+
+	/* eslint quote-props: [2, "as-needed"] */
+	var predefinedRules = {
+		ImportDeclaration: function (node) {
+			if (!isTestFile && deepStrictEqual(espurify(node), avaImportDeclarationAst)) {
+				isTestFile = true;
+			}
+		},
+		VariableDeclarator: function (node) {
+			if (!isTestFile && deepStrictEqual(espurify(node), avaVariableDeclaratorAst)) {
+				isTestFile = true;
+			}
+		},
+		CallExpression: function (node) {
+			if (!currentTestNode) {
+				if (isTestFunctionCall(node.callee)) {
+					// entering test function
+					currentTestNode = node;
+				}
+			}
+		},
+		'CallExpression:exit': function (node) {
+			if (currentTestNode === node) {
+				// leaving test function
+				currentTestNode = null;
+			}
+		},
+		'Program:exit': function () {
+			isTestFile = false;
+		}
+	};
+
+	var rule = {
+		hasTestModifier: function (mod) {
+			return hasTestModifier(currentTestNode, mod);
+		},
+		merge: function (customHandlers) {
+			Object.keys(predefinedRules).forEach(function (key) {
+				var predef = predefinedRules[key];
+				if (typeof customHandlers[key] === 'function') {
+					predefinedRules[key] = function (node) {
+						if (/:exit$/.test(key)) {
+							customHandlers[key](node);
+							predef(node); // append predefined rules on exit
+						} else {
+							predef(node); // prepend predefined rules on enter
+							customHandlers[key](node);
+						}
+					};
+				}
+			});
+			return Object.assign({}, customHandlers, predefinedRules);
+		}
+	};
+	Object.defineProperty(rule, 'isTestFile', {
+		get: function () {
+			return isTestFile;
+		}
+	});
+	Object.defineProperty(rule, 'currentTestNode', {
+		get: function () {
+			return currentTestNode;
+		}
+	});
+	return rule;
+};

--- a/create-ava-rule.js
+++ b/create-ava-rule.js
@@ -1,5 +1,6 @@
 'use strict';
 var espurify = require('espurify');
+var assign = require('object-assign');
 var deepStrictEqual = require('deep-strict-equal');
 
 var avaImportDeclarationAst = {
@@ -116,7 +117,7 @@ module.exports = function createAvaRule() {
 					};
 				}
 			});
-			return Object.assign({}, customHandlers, predefinedRules);
+			return assign({}, customHandlers, predefinedRules);
 		}
 	};
 	Object.defineProperty(rule, 'isTestFile', {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   ],
   "dependencies": {
     "deep-strict-equal": "^0.1.0",
-    "espurify": "^1.5.0"
+    "espurify": "^1.5.0",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "ava": "*",

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -1,6 +1,7 @@
 'use strict';
 var espurify = require('espurify');
 var deepStrictEqual = require('deep-strict-equal');
+var createAvaRule = require('../create-ava-rule');
 
 var notAllowed = [
 	'notOk',
@@ -11,54 +12,6 @@ var notAllowed = [
 	'regex',
 	'ifError'
 ];
-
-var avaImportDeclarationAst = {
-	type: 'ImportDeclaration',
-	specifiers: [
-		{
-			type: 'ImportDefaultSpecifier',
-			local: {
-				type: 'Identifier',
-				name: 'test'
-			}
-		}
-	],
-	source: {
-		type: 'Literal',
-		value: 'ava'
-	}
-};
-
-var avaVariableDeclaratorAst = {
-	type: 'VariableDeclarator',
-	id: {
-		type: 'Identifier',
-		name: 'test'
-	},
-	init: {
-		type: 'CallExpression',
-		callee: {
-			type: 'Identifier',
-			name: 'require'
-		},
-		arguments: [
-			{
-				type: 'Literal',
-				value: 'ava'
-			}
-		]
-	}
-};
-
-function isTestFunctionCall(node) {
-	if (node.type === 'Identifier') {
-		return node.name === 'test';
-	} else if (node.type === 'MemberExpression') {
-		return isTestFunctionCall(node.object);
-	}
-
-	return false;
-}
 
 function assertionCalleeAst(methodName) {
 	return {
@@ -105,38 +58,13 @@ function isCalleeMatched(callee, methodName) {
 
 /* eslint quote-props: [2, "as-needed"] */
 module.exports = function (context) {
-	var isTestFile = false;
-	var currentTestNode = null;
-
-	return {
-		ImportDeclaration: function (node) {
-			if (!isTestFile && deepStrictEqual(espurify(node), avaImportDeclarationAst)) {
-				isTestFile = true;
-			}
-		},
-		VariableDeclarator: function (node) {
-			if (!isTestFile && deepStrictEqual(espurify(node), avaVariableDeclaratorAst)) {
-				isTestFile = true;
-			}
-		},
+	var ava = createAvaRule();
+	return ava.merge({
 		CallExpression: function (node) {
-			if (!isTestFile) {
-				// not in test file
+			if (!ava.isTestFile || !ava.currentTestNode) {
 				return;
 			}
-
 			var callee = espurify(node.callee);
-
-			if (!currentTestNode) {
-				if (isTestFunctionCall(callee)) {
-					// entering test function
-					currentTestNode = node;
-				}
-
-				// not in test function
-				return;
-			}
-
 			if (callee.type === 'MemberExpression') {
 				notAllowed.forEach(function (methodName) {
 					if (isCalleeMatched(callee, methodName)) {
@@ -144,15 +72,6 @@ module.exports = function (context) {
 					}
 				});
 			}
-		},
-		'CallExpression:exit': function (node) {
-			if (currentTestNode === node) {
-				currentTestNode = null;
-				return;
-			}
-		},
-		'Program:exit': function () {
-			isTestFile = false;
 		}
-	};
+	});
 };

--- a/test/test-ended.js
+++ b/test/test-ended.js
@@ -19,6 +19,11 @@ test(() => {
 			header + 'test.cb(t => { t.pass(); t.end(); });',
 			header + 'test.cb(t => { t.end(); });',
 			header + 'test.cb(t => { t.end(); t.pass(); });',
+			header + 'test.cb.only(t => { t.end(); });',
+			header + 'test.cb.skip.only(t => { t.end(); });',
+			header + 'test.only.cb.skip(t => { t.end(); });',
+			// shouldn't be triggered since it's not a callback test
+			header + 'test(t => { t.pass(); });',
 			// shouldn't be triggered since it's not a test file
 			'test.cb(t => {});'
 		],
@@ -33,6 +38,14 @@ test(() => {
 			},
 			{
 				code: header + 'test.cb(t => {});',
+				errors
+			},
+			{
+				code: header + 'test.cb.skip.only(t => {});',
+				errors
+			},
+			{
+				code: header + 'test.only.cb.skip(t => {});',
 				errors
 			}
 		]


### PR DESCRIPTION
Extracted minimal framework through refactoring.

- `ava` require/import detection
- `test` function detection
- provide getter access to current enclosing `test` function node
- predicate method for test modifiers

Please see `rules/test-ended.js` for usage.

fixes #12