### PR TITLE
add no-todo-test rule (fixes #31)

### DIFF
--- a/docs/rules/no-todo-test.md
+++ b/docs/rules/no-todo-test.md
@@ -1,0 +1,23 @@
+# Ensure no `test.todo()` is used
+
+Disallow the use of `test.todo()`. You might want to do this to only ship features with specs fully written and passing.
+
+
+## Fail
+
+```js
+import test from 'ava';
+
+test.todo('some test');
+```
+
+
+## Pass
+
+```js
+import test from 'ava';
+
+test('some test', t => {
+	// Some implementation
+});
+```

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
 		'no-only-test': require('./rules/no-only-test'),
 		'no-skip-assert': require('./rules/no-skip-assert'),
 		'no-skip-test': require('./rules/no-skip-test'),
+		'no-todo-test': require('./rules/no-todo-test'),
 		'prefer-power-assert': require('./rules/prefer-power-assert'),
 		'test-ended': require('./rules/test-ended'),
 		'test-title': require('./rules/test-title')
@@ -30,6 +31,7 @@ module.exports = {
 				'no-only-test': 2,
 				'no-skip-assert': 2,
 				'no-skip-test': 2,
+				'no-todo-test': 1,
 				'prefer-power-assert': 0,
 				'test-ended': 2,
 				'test-title': [2, 'always']

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ Configure it in `package.json`.
 			"ava/no-only-test": 2,
 			"ava/no-skip-assert": 2,
 			"ava/no-skip-test": 2,
+			"ava/no-todo-test": 1,
 			"ava/prefer-power-assert": 0,
 			"ava/test-ended": 2,
 			"ava/test-title": [2, "always"]
@@ -56,6 +57,7 @@ The rules will only activate in test files.
 - [no-only-test](docs/rules/no-only-test.md) - Ensure no `test.only()` are present.
 - [no-skip-assert](docs/rules/no-skip-assert.md) - Ensure no assertions are skipped.
 - [no-skip-test](docs/rules/no-skip-test.md) - Ensure no tests are skipped.
+- [no-todo-test](docs/rules/no-todo-test.md) - Ensure no `test.todo()` is used.
 - [prefer-power-assert](docs/rules/prefer-power-assert.md) - Allow only use of the asserts that have no [power-assert](https://github.com/power-assert-js/power-assert) alternative.
 - [test-ended](docs/rules/test-ended.md) - Ensure callback tests are explicitly ended.
 - [test-title](docs/rules/test-title.md) - Ensure tests have a title.

--- a/rules/no-todo-test.js
+++ b/rules/no-todo-test.js
@@ -1,0 +1,14 @@
+'use strict';
+var createAvaRule = require('../create-ava-rule');
+
+module.exports = function (context) {
+	var ava = createAvaRule();
+
+	return ava.merge({
+		CallExpression: function (node) {
+			if (ava.isTestFile && ava.currentTestNode === node && ava.hasTestModifier('todo')) {
+				context.report(node, '`test.todo()` should be not be used.');
+			}
+		}
+	});
+};

--- a/test/no-todo-test.js
+++ b/test/no-todo-test.js
@@ -1,0 +1,38 @@
+import test from 'ava';
+import {RuleTester} from 'eslint';
+import rule from '../rules/no-todo-test';
+
+const ruleTester = new RuleTester({
+	env: {
+		es6: true
+	}
+});
+
+const errors = [{ruleId: 'no-todo-test'}];
+const header = `const test = require('ava');\n`;
+
+test(() => {
+	ruleTester.run('no-todo-test', rule, {
+		valid: [
+			header + 'test("my test name", function (t) { t.pass(); });',
+			header + 'test.only("my test name", function (t) { t.pass(); });',
+			header + 'notTest.todo(function (t) { t.pass(); });',
+			// shouldn't be triggered since it's not a test file
+			'test.todo("my test name");'
+		],
+		invalid: [
+			{
+				code: header + 'test.todo("my test name");',
+				errors
+			},
+			{
+				code: header + 'test.todo.cb("my test name");',
+				errors
+			},
+			{
+				code: header + 'test.cb.todo("my test name");',
+				errors
+			}
+		]
+	});
+});


### PR DESCRIPTION
Adds no-todo-test rule (fixes #31).

Let's wait until https://github.com/sindresorhus/ava/pull/565 lands before merging (or at least releasing) it, but we can already discuss the implementation (it's pretty much a no-skip-test copy and paste).