### PR TITLE
Fix incorrect no-identical-rule errors for title expressions

### DIFF
--- a/test/no-identical-title.js
+++ b/test/no-identical-title.js
@@ -16,9 +16,13 @@ test(() => {
 	ruleTester.run('no-identical-title', rule, {
 		valid: [
 			header + 'test("my test name", function (t) { t.pass(); });',
-			header + 'test(function (t) { t.pass(); });',
+			header + 'test("a", function (t) { t.pass(); }); test(function (t) { t.pass(); });',
 			header + 'test("a", function (t) { t.pass(); }); test("b", function (t) { t.pass(); });',
 			header + 'test("a", function (t) { t.pass(); }); test.cb("b", function (t) { t.pass(); });',
+			header + 'test("a", t => {}); notTest("a", t => {});',
+			header + 'const name = "foo"; test(`${name} 1`, function (t) { t.pass(); }); test(`${name} 2`,  function (t) { t.pass(); });',
+			header + 'const name = "foo"; test(name + " 1", function (t) { t.pass(); }); test(name + " 2", function (t) { t.pass(); });',
+			header + 'test("a", t => {}); notTest("a", t => {});',
 			header + 'notTest("a", t => {}); notTest("a", t => {});',
 			// shouldn't be triggered since it's not a test file
 			'test(t => {}); test(t => {});',
@@ -27,6 +31,10 @@ test(() => {
 		invalid: [
 			{
 				code: header + `test("a", ${testFunction}); test("a", ${testFunction});`,
+				errors
+			},
+			{
+				code: header + `test(${testFunction}); test(${testFunction});`,
 				errors
 			},
 			{
@@ -43,6 +51,14 @@ test(() => {
 			},
 			{
 				code: header + `test(${testFunction}); test.cb(${testFunction});`,
+				errors
+			},
+			{
+				code: header + 'const name = "foo"; test(`${name} 1`, function (t) { t.pass(); }); test(`${name} 1`, function (t) { t.pass(); });',
+				errors
+			},
+			{
+				code: header + 'const name = "foo"; test(name + " 1", function (t) { t.pass(); }); test(name + " 1", function (t) { t.pass(); });',
 				errors
 			}
 		]


### PR DESCRIPTION
I noticed that the rule gets incorrectly triggered when using non-string literals (binary expressions, template literals...). Now I compare the nodes rather than the value of the title (which was undefined in the case of template literals for example...).

I also added a few tests of cases I could think of but that were already ok.

I can still see two edge cases for this rule, but I don't think we can really do much against (thought I should at least write them somewhere):
- Same title node used in different contexts (False error):
```js
let name = 'foo';
test(name, t => {
  t.is(foo(), 1);
});

name = 'bar';
test(name, t => {
  t.is(bar(), 1);
});
```

- Same expression value, but with different nodes (false pass):
```js
test("ab", t => { ... });
test("a"+"b", t => { ... });
```
