### PR TITLE
Fix errors with `test.todo()`

### DIFF
--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -26,7 +26,7 @@ module.exports = function (context) {
 			}
 
 			var args = node.arguments;
-			var titleNode = args.length > 1 ? args[0] : undefined;
+			var titleNode = args.length > 1 || ava.hasTestModifier('todo') ? args[0] : undefined;
 			if (isTitleUsed(usedTitleNodes, titleNode)) {
 				context.report(node, 'Test title is used multiple times in the same file.');
 				return;

--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -15,7 +15,8 @@ module.exports = function (context) {
 
 			testCount++;
 
-			var hasNoTitle = node.arguments.length !== 2;
+			var requiredLength = ava.hasTestModifier('todo') ? 1 : 2;
+			var hasNoTitle = node.arguments.length !== requiredLength;
 			var isOverThreshold = !ifMultiple || testCount > 1;
 
 			if (hasNoTitle && isOverThreshold) {

--- a/test/no-identical-title.js
+++ b/test/no-identical-title.js
@@ -19,6 +19,7 @@ test(() => {
 			header + 'test("a", function (t) { t.pass(); }); test(function (t) { t.pass(); });',
 			header + 'test("a", function (t) { t.pass(); }); test("b", function (t) { t.pass(); });',
 			header + 'test("a", function (t) { t.pass(); }); test.cb("b", function (t) { t.pass(); });',
+			header + 'test.todo("a"); test.todo("b");',
 			header + 'test("a", t => {}); notTest("a", t => {});',
 			header + 'const name = "foo"; test(`${name} 1`, function (t) { t.pass(); }); test(`${name} 2`,  function (t) { t.pass(); });',
 			header + 'const name = "foo"; test(name + " 1", function (t) { t.pass(); }); test(name + " 2", function (t) { t.pass(); });',
@@ -51,6 +52,10 @@ test(() => {
 			},
 			{
 				code: header + `test(${testFunction}); test.cb(${testFunction});`,
+				errors
+			},
+			{
+				code: header + `test.todo("a"); test.todo("a");`,
 				errors
 			},
 			{

--- a/test/test-title.js
+++ b/test/test-title.js
@@ -18,6 +18,7 @@ test(() => {
 			header + 'test(`my test name`, function (t) { t.pass(); t.end(); });',
 			header + 'test(\'my test name\', function (t) { t.pass(); t.end(); });',
 			header + 'test.cb("my test name", t => { t.pass(); t.end(); });',
+			header + 'test.todo("my test name");',
 			{
 				code: header + 'test(function (t) { t.pass(); t.end(); });',
 				options: ['if-multiple']
@@ -41,6 +42,10 @@ test(() => {
 			},
 			{
 				code: header + 'test(t => { t.pass(); t.end(); });',
+				errors
+			},
+			{
+				code: header + 'test.todo();',
 				errors
 			},
 			{


### PR DESCRIPTION
Fixes a couple issues when using `test.todo()`:

* `test-title` incorrectly reports that the test doesn’t have a title when it does
* `no-identical-title` wasn’t pulling the right title, so if you had multiple `test.todo()`s in the file, it would error when it shouldn’t have