### PR TITLE
Fix `no-identical-title` for dynamic template strings

### DIFF
--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -7,11 +7,22 @@ function purify(node) {
 	return node && espurify(node);
 }
 
+function isStaticTemplateLiteral(node) {
+	return node.expressions.every(isStatic);
+}
+
+function isStatic(node) {
+	return !node ||
+		node.type === 'Literal' ||
+		(node.type === 'TemplateLiteral' && isStaticTemplateLiteral(node)) ||
+		(node.type === 'BinaryExpression' && isStatic(node.left) && isStatic(node.right));
+}
+
 function isTitleUsed(usedTitleNodes, titleNode) {
 	var purifiedNode = purify(titleNode);
-	return usedTitleNodes.reduce(function (prev, usedTitle) {
-		return prev || deepStrictEqual(purifiedNode, usedTitle);
-	}, false);
+	return usedTitleNodes.some(function (usedTitle) {
+		return deepStrictEqual(purifiedNode, usedTitle);
+	});
 }
 
 /* eslint quote-props: [2, "as-needed"] */
@@ -27,6 +38,10 @@ module.exports = function (context) {
 
 			var args = node.arguments;
 			var titleNode = args.length > 1 || ava.hasTestModifier('todo') ? args[0] : undefined;
+			if (!isStatic(titleNode)) {
+				return;
+			}
+
 			if (isTitleUsed(usedTitleNodes, titleNode)) {
 				context.report(node, 'Test title is used multiple times in the same file.');
 				return;

--- a/test/no-identical-title.js
+++ b/test/no-identical-title.js
@@ -10,19 +10,18 @@ const ruleTester = new RuleTester({
 
 const errors = [{ruleId: 'no-identical-title'}];
 const header = `const test = require('ava');\n`;
-const testFunction = `function (t) { t.pass(); }`;
 
 test(() => {
 	ruleTester.run('no-identical-title', rule, {
 		valid: [
-			header + 'test("my test name", function (t) { t.pass(); });',
-			header + 'test("a", function (t) { t.pass(); }); test(function (t) { t.pass(); });',
-			header + 'test("a", function (t) { t.pass(); }); test("b", function (t) { t.pass(); });',
-			header + 'test("a", function (t) { t.pass(); }); test.cb("b", function (t) { t.pass(); });',
+			header + 'test("my test name", t => {});',
+			header + 'test("a", t => {}); test(t => {});',
+			header + 'test("a", t => {}); test("b", t => {});',
+			header + 'test("a", t => {}); test.cb("b", t => {});',
 			header + 'test.todo("a"); test.todo("b");',
 			header + 'test("a", t => {}); notTest("a", t => {});',
-			header + 'const name = "foo"; test(`${name} 1`, function (t) { t.pass(); }); test(`${name} 2`,  function (t) { t.pass(); });',
-			header + 'const name = "foo"; test(name + " 1", function (t) { t.pass(); }); test(name + " 2", function (t) { t.pass(); });',
+			header + 'test(`foo ${name}`, t => {}); test(`foo ${name}`,  t => {});',
+			header + 'const name = "foo"; test(name + " 1", t => {}); test(name + " 1", t => {});',
 			header + 'test("a", t => {}); notTest("a", t => {});',
 			header + 'notTest("a", t => {}); notTest("a", t => {});',
 			// shouldn't be triggered since it's not a test file
@@ -31,39 +30,43 @@ test(() => {
 		],
 		invalid: [
 			{
-				code: header + `test("a", ${testFunction}); test("a", ${testFunction});`,
+				code: header + 'test("a", t => {}); test("a", t => {});',
 				errors
 			},
 			{
-				code: header + `test(${testFunction}); test(${testFunction});`,
+				code: header + 'test(`a`, t => {}); test(`a`, t => {});',
 				errors
 			},
 			{
-				code: header + `test("a", ${testFunction}); test.cb("a", ${testFunction});`,
+				code: header + 'test(t => {}); test(t => {});',
 				errors
 			},
 			{
-				code: header + `test("a", ${testFunction}); test.cb.skip("a", ${testFunction});`,
+				code: header + 'test("a", t => {}); test.cb("a", t => {});',
 				errors
 			},
 			{
-				code: header + `test("foo" + 1, ${testFunction}); test("foo" + 1, ${testFunction});`,
+				code: header + 'test(`a`, t => {}); test.cb(`a`, t => {});',
 				errors
 			},
 			{
-				code: header + `test(${testFunction}); test.cb(${testFunction});`,
+				code: header + 'test("a", t => {}); test.cb.skip("a", t => {});',
 				errors
 			},
 			{
-				code: header + `test.todo("a"); test.todo("a");`,
+				code: header + 'test("foo" + 1, t => {}); test("foo" + 1, t => {});',
 				errors
 			},
 			{
-				code: header + 'const name = "foo"; test(`${name} 1`, function (t) { t.pass(); }); test(`${name} 1`, function (t) { t.pass(); });',
+				code: header + 'test(`${"foo" + 1}`, t => {}); test(`${"foo" + 1}`, t => {});',
 				errors
 			},
 			{
-				code: header + 'const name = "foo"; test(name + " 1", function (t) { t.pass(); }); test(name + " 1", function (t) { t.pass(); });',
+				code: header + 'test(t => {}); test.cb(t => {});',
+				errors
+			},
+			{
+				code: header + 'test.todo("a"); test.todo("a");',
 				errors
 			}
 		]


### PR DESCRIPTION
Fixes #43.
The `no-indentical-rule` now tries to determine whether the title is dynamic (= contains a variable) or not, so that it doesn't flag titles like `\ ̀ ensure x=${expected} \ ̀`, but still flags titles like `\ ̀ ensure x=2 \ ̀` or `\ ̀ ensure x=${1 + 3}\ ̀` (template strings without any variables). Did the same thing for titles like "foo" + 1.
I feel like I'm forgetting cases, but it should fix #43 at least.

Note: also simplified the tests to use `t => {}` rather than `function() {}`