### PR TITLE
Fix typo in no-invalid-end.js

### DIFF
--- a/rules/no-invalid-end.js
+++ b/rules/no-invalid-end.js
@@ -12,7 +12,7 @@ module.exports = function (context) {
 					node.property.name === 'end' &&
 					!ava.hasTestModifier('cb') &&
 					util.nameOfRootObject(node) === 't') {
-				context.report(node, '`test.end()` should only be used inside of `test.cb()`.');
+				context.report(node, '`t.end()` should only be used inside of `test.cb()`.');
 			}
 		}
 	});


### PR DESCRIPTION
It's t.end(), no test.end(), isn't it?