### PR TITLE
Fix incorrect exit visitors

### DIFF
--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -51,7 +51,7 @@ module.exports = function (context) {
 
 			usedTitleNodes.push(purify(titleNode));
 		},
-		'Program.exit': function () {
+		'Program:exit': function () {
 			usedTitleNodes = [];
 		}
 	});

--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -23,7 +23,7 @@ module.exports = function (context) {
 				context.report(node, 'Test should have a title.');
 			}
 		},
-		'Program.exit': function () {
+		'Program:exit': function () {
 			testCount = 0;
 		}
 	});


### PR DESCRIPTION
Fix incorrect exit visitors: we were using `Program.exit` in some places we should have been using `Program:exit`.