### PR TITLE
Update the `prefer-power-assert` rule for AVA assert changes

### DIFF
--- a/docs/rules/prefer-power-assert.md
+++ b/docs/rules/prefer-power-assert.md
@@ -1,8 +1,8 @@
 # Allow only use of the asserts that have no power-assert alternative.
 
-- [`t.ok()`](https://github.com/sindresorhus/ava#okvalue-message) __(You can do [most things](https://github.com/sindresorhus/ava#enhanced-asserts) with this one)__
-- [`t.same()`](https://github.com/sindresorhus/ava#samevalue-expected-message)
-- [`t.notSame()`](https://github.com/sindresorhus/ava#notsamevalue-expected-message)
+- [`t.truthy()`](https://github.com/sindresorhus/ava#truthyvalue-message) __(You can do [most things](https://github.com/sindresorhus/ava#enhanced-assertion-messages) with this one)__
+- [`t.deepEqual()`](https://github.com/sindresorhus/ava#deepequalvalue-expected-message)
+- [`t.notDeepEqual()`](https://github.com/sindresorhus/ava#notdeepequalvalue-expected-message)
 - [`t.throws()`](https://github.com/sindresorhus/ava#throwsfunctionpromise-error-message)
 - [`t.notThrows()`](https://github.com/sindresorhus/ava#notthrowsfunctionpromise-message)
 - [`t.pass()`](https://github.com/sindresorhus/ava#passmessage)
@@ -28,6 +28,6 @@ test(t => {
 import test from 'ava';
 
 test(t => {
-	t.ok(foo === bar);
+	t.truthy(foo === bar);
 });
 ```

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -4,7 +4,7 @@ var deepStrictEqual = require('deep-strict-equal');
 var createAvaRule = require('../create-ava-rule');
 
 var notAllowed = [
-	'notOk',
+	'falsy',
 	'true',
 	'false',
 	'is',

--- a/test/prefer-power-assert.js
+++ b/test/prefer-power-assert.js
@@ -34,7 +34,7 @@ function testNotAllowedMethod(methodName) {
 }
 
 const notAllowedMethods = [
-	'notOk(foo)',
+	'falsy(foo)',
 	'true(foo)',
 	'false(foo)',
 	'is(foo, bar)',
@@ -64,9 +64,9 @@ function testAllowedMethod(methodName) {
 }
 
 const allowedMethods = [
-	'ok(foo)',
-	'same(foo, bar)',
-	'notSame(foo, bar)',
+	'truthy(foo)',
+	'deepEqual(foo, bar)',
+	'notDeepEqual(foo, bar)',
 	'throws(block)',
 	'notThrows(block)'
 ];
@@ -80,12 +80,12 @@ function testWithModifier(modifier) {
 		ruleTester.run('prefer-power-assert', rule, {
 			valid: [
 				{
-					code: `import test from 'ava';\n test.${modifier}(t => { t.ok(foo); });`
+					code: `import test from 'ava';\n test.${modifier}(t => { t.truthy(foo); });`
 				}
 			],
 			invalid: [
 				{
-					code: `import test from 'ava';\n test.${modifier}(t => { t.notOk(foo); });`,
+					code: `import test from 'ava';\n test.${modifier}(t => { t.falsy(foo); });`,
 					errors
 				}
 			]
@@ -102,12 +102,12 @@ function testDeclaration(declaration) {
 		ruleTester.run('prefer-power-assert', rule, {
 			valid: [
 				{
-					code: `${declaration}\n test(t => { t.ok(foo); });`
+					code: `${declaration}\n test(t => { t.truthy(foo); });`
 				}
 			],
 			invalid: [
 				{
-					code: `${declaration}\n test(t => { t.notOk(foo); });`,
+					code: `${declaration}\n test(t => { t.falsy(foo); });`,
 					errors
 				}
 			]
@@ -152,7 +152,7 @@ test('misc', () => {
 	ruleTester.run('prefer-power-assert', rule, {
 		valid: [
 			{
-				code: `import test from 'ava';\n test.cb(function (t) { t.ok(foo); t.end(); });`
+				code: `import test from 'ava';\n test.cb(function (t) { t.truthy(foo); t.end(); });`
 			},
 			// shouldn't be triggered since it's not a test file
 			{


### PR DESCRIPTION
Fixes #62

* rename `t.same()` to `t.deepEqual()`
* rename `t.notSame()` to `t.notDeepEqual()`
* rename `t.ok()` to `t.truthy()`
* rename `t.notOk()` to `t.falsy()`
* change bad link to "Enhanced assertion messages"

This is my first PR, be kind :smile: 