### PR TITLE
fix(test-ended): false positive when passing `t.end` as a callback. Fixes #60.

### DIFF
--- a/docs/rules/test-ended.md
+++ b/docs/rules/test-ended.md
@@ -23,4 +23,8 @@ test.cb(t => {
 	t.pass();
 	t.end();
 });
+
+test.cb(t => {
+	acceptsCallback(t.end);
+});
 ```

--- a/rules/test-ended.js
+++ b/rules/test-ended.js
@@ -7,14 +7,12 @@ module.exports = function (context) {
 	var endCalled = false;
 
 	return ava.merge({
-		CallExpression: function (node) {
+		MemberExpression: function (node) {
 			if (!ava.isTestFile || !ava.currentTestNode || !ava.hasTestModifier('cb')) {
 				return;
 			}
 
-			var callee = node.callee;
-
-			if (callee.type === 'MemberExpression' && callee.object.name === 't' && callee.property.name === 'end') {
+			if (node.object.name === 't' && node.property.name === 'end') {
 				endCalled = true;
 			}
 		},

--- a/test/test-ended.js
+++ b/test/test-ended.js
@@ -19,6 +19,7 @@ test(() => {
 			header + 'test.cb(t => { t.pass(); t.end(); });',
 			header + 'test.cb(t => { t.end(); });',
 			header + 'test.cb(t => { t.end(); t.pass(); });',
+			header + 'test.cb(t => { fn(t.end); });',
 			header + 'test.cb.only(t => { t.end(); });',
 			header + 'test.cb.skip.only(t => { t.end(); });',
 			header + 'test.only.cb.skip(t => { t.end(); });',


### PR DESCRIPTION
Fixes #60.