### PR TITLE
Use "error" in rule docs, add missing ava/ prefix

### DIFF
--- a/docs/rules/max-asserts.md
+++ b/docs/rules/max-asserts.md
@@ -8,7 +8,7 @@ Skipped assertions are counted.
 ## Fail
 
 ```js
-/*eslint max-asserts: [2, 5]*/
+/*eslint ava/max-asserts: ["error", 5]*/
 import test = from 'ava';
 
 test('getSomeObject should define the players\' names', t => {
@@ -56,5 +56,5 @@ The rule takes one option, a number, which is the maximum number of assertions f
 You can set the option in configuration like this:
 
 ```js
-"ava/max-asserts": [2, 5]
+"ava/max-asserts": ["error", 5]
 ```

--- a/docs/rules/no-ignored-test-files.md
+++ b/docs/rules/no-ignored-test-files.md
@@ -88,5 +88,5 @@ This rule supports the following options:
 You can set the options like this:
 
 ```js
-"ava/no-ignored-test-files": [2, {"files": ["lib/**/*.test.js", "utils/**/*.test.js"]}]
+"ava/no-ignored-test-files": ["error", {"files": ["lib/**/*.test.js", "utils/**/*.test.js"]}]
 ```


### PR DESCRIPTION
Missed some `2` --> `"error"` changes, and in some examples, we used
```js
/*eslint max-asserts: [2, 5]*/
```
but it was missing the `ava/` prefix (--> `ava/max-asserts`)