### PR TITLE
Add `assertion-message` rule (fixes #59)

### DIFF
--- a/docs/rules/assertion-message.md
+++ b/docs/rules/assertion-message.md
@@ -1,0 +1,47 @@
+# Enforce or disallow assertion messages
+
+Assertion messages are optional arguments that can be given to any assertion call to improve the error message, should the assertion fail. This rule either enforces or disallows the use of those messages.
+
+
+## Fail
+
+```js
+import test from 'ava';
+
+/*eslint ava/assertion-message: ["error", "always"]*/
+test(t => {
+	t.truthy(array.indexOf(value) !== -1);
+});
+
+/*eslint ava/assertion-message: ["error", "never"]*/
+test(t => {
+	t.truthy(array.indexOf(value) !== -1, 'value is not in array');
+});
+```
+
+
+## Pass
+
+```js
+import test from 'ava';
+
+/*eslint ava/assertion-message: ["error", "always"]*/
+test(t => {
+	t.truthy(array.indexOf(value) !== -1, 'value is not in array');
+});
+
+/*eslint ava/assertion-message: ["error", "never"]*/
+test(t => {
+	t.truthy(array.indexOf(value) !== -1);
+});
+```
+
+## Options
+
+The rule takes one option, a string, which could be either `"always"` or `"never"`. The default is `"always"`.
+
+You can set the option in configuration like this:
+
+```js
+"ava/assertion-message": ["error", "always"]
+```

--- a/docs/rules/assertion-message.md
+++ b/docs/rules/assertion-message.md
@@ -8,14 +8,14 @@ Assertion messages are optional arguments that can be given to any assertion cal
 ```js
 import test from 'ava';
 
-/*eslint ava/assertion-message: ["error", "always"]*/
+/* eslint ava/assertion-message: ["error", "always"] */
 test(t => {
-	t.truthy(array.indexOf(value) !== -1);
+	t.true(array.indexOf(value) !== -1);
 });
 
-/*eslint ava/assertion-message: ["error", "never"]*/
+/* eslint ava/assertion-message: ["error", "never"] */
 test(t => {
-	t.truthy(array.indexOf(value) !== -1, 'value is not in array');
+	t.true(array.indexOf(value) !== -1, 'value is not in array');
 });
 ```
 
@@ -25,14 +25,14 @@ test(t => {
 ```js
 import test from 'ava';
 
-/*eslint ava/assertion-message: ["error", "always"]*/
+/* eslint ava/assertion-message: ["error", "always"] */
 test(t => {
-	t.truthy(array.indexOf(value) !== -1, 'value is not in array');
+	t.true(array.indexOf(value) !== -1, 'value is not in array');
 });
 
-/*eslint ava/assertion-message: ["error", "never"]*/
+/* eslint ava/assertion-message: ["error", "never"] */
 test(t => {
-	t.truthy(array.indexOf(value) !== -1);
+	t.true(array.indexOf(value) !== -1);
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	rules: {
+		'assertion-message': require('./rules/assertion-message'),
 		'max-asserts': require('./rules/max-asserts'),
 		'no-cb-test': require('./rules/no-cb-test'),
 		'no-identical-title': require('./rules/no-identical-title'),
@@ -29,6 +30,7 @@ module.exports = {
 				sourceType: 'module'
 			},
 			rules: {
+				'ava/assertion-message': ['off', 'always'],
 				'ava/max-asserts': ['off', 5],
 				'ava/no-cb-test': 'off',
 				'ava/no-identical-title': 'error',

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ Configure it in `package.json`.
 			"ava"
 		],
 		"rules": {
+			"ava/assertion-message": ["off", "always"],
 			"ava/max-asserts": ["off", 5],
 			"ava/no-cb-test": "off",
 			"ava/no-identical-title": "error",
@@ -55,6 +56,7 @@ Configure it in `package.json`.
 
 The rules will only activate in test files.
 
+- [assertion-message](docs/rules/assertion-message.md) - Enforce or disallow assertion messages.
 - [max-asserts](docs/rules/max-asserts.md) - Limit the number of assertions in a test.
 - [no-cb-test](docs/rules/no-cb-test.md) - Ensure no `test.cb()` is used.
 - [no-identical-title](docs/rules/no-identical-title.md) - Ensure no tests have the same title.

--- a/rules/assertion-message.js
+++ b/rules/assertion-message.js
@@ -1,0 +1,65 @@
+'use strict';
+var util = require('../util');
+var createAvaRule = require('../create-ava-rule');
+
+var expectedNbArguments = {
+	deepEqual: 2,
+	fail: 0,
+	false: 1,
+	falsy: 1,
+	ifError: 1,
+	is: 2,
+	not: 2,
+	notDeepEqual: 2,
+	notThrows: 1,
+	pass: 0,
+	regex: 2,
+	throws: 1,
+	true: 1,
+	truthy: 1
+};
+
+function nbArguments(node) {
+	var nArgs = expectedNbArguments[node.property.name];
+	if (nArgs !== undefined) {
+		return nArgs;
+	}
+
+	if (node.object.type === 'MemberExpression') {
+		return nbArguments(node.object);
+	}
+
+	return -1;
+}
+
+module.exports = function (context) {
+	var ava = createAvaRule();
+	var shouldHaveMessage = context.options[0] !== 'never';
+
+	return ava.merge({
+		CallExpression: function (node) {
+			if (!ava.isTestFile || !ava.currentTestNode || node.callee.type !== 'MemberExpression') {
+				return;
+			}
+
+			var callee = node.callee;
+			if (callee.property && util.nameOfRootObject(callee) === 't') {
+				var nArgs = nbArguments(callee);
+				if (nArgs === -1) {
+					return;
+				}
+
+				var hasMessage = nArgs < node.arguments.length;
+				if (!hasMessage && shouldHaveMessage) {
+					context.report(node, 'Expected an assertion message, but found none');
+				} else if (hasMessage && !shouldHaveMessage) {
+					context.report(node, 'Expected no assertion message, but found one');
+				}
+			}
+		}
+	});
+};
+
+module.exports.schema = [{
+	enum: ['always', 'never']
+}];

--- a/test/assertion-message.js
+++ b/test/assertion-message.js
@@ -1,0 +1,118 @@
+import test from 'ava';
+import {RuleTester} from 'eslint';
+import rule from '../rules/assertion-message';
+
+const ruleTester = new RuleTester({
+	env: {
+		es6: true
+	}
+});
+
+const missingError = [{
+	ruleId: 'assertion-message',
+	message: 'Expected an assertion message, but found none'
+}];
+
+const foundError = [{
+	ruleId: 'assertion-message',
+	message: 'Expected no assertion message, but found one'
+}];
+
+const header = `const test = require('ava');`;
+
+function testCase(option, content, errors, useHeader) {
+	const testFn = `
+		test(t => {
+			${content}
+		});
+	`;
+	return {
+		errors: errors || [],
+		options: [option],
+		code: (useHeader === false ? '' : header) + testFn
+	};
+}
+
+test(() => {
+	ruleTester.run('assertion-message', rule, {
+		valid: [
+			testCase('always', `t.pass('message');`),
+			testCase('always', `t.fail('message');`),
+			testCase('always', `t.truthy('unicorn', 'message');`),
+			testCase('always', `t.falsy('unicorn', 'message');`),
+			testCase('always', `t.true(true, 'message');`),
+			testCase('always', `t.false(false, 'message');`),
+			testCase('always', `t.is('same', 'same', 'message');`),
+			testCase('always', `t.not('not', 'same', 'message');`),
+			testCase('always', `t.deepEqual({}, {}, 'message');`),
+			testCase('always', `t.notDeepEqual({}, {a: true}, 'message');`),
+			testCase('always', `t.throws(Promise.reject(), 'message');`),
+			testCase('always', `t.notThrows(Promise.resolve(), 'message');`),
+			testCase('always', `t.regex(a, /a/, 'message');`),
+			testCase('always', `t.ifError(new Error(), 'message');`),
+			testCase('always', `t.skip.is('same', 'same', 'message');`),
+			testCase('always', `t.is.skip('same', 'same', 'message');`),
+			testCase('always', `t.plan('a', 'b', 'c', 'd', 'message');`),
+			testCase('always', `t.end('a', 'b', 'c', 'd', 'message');`),
+			// shouldn't be triggered since it's not a test file
+			testCase('always', `t.true(true);`, [], false),
+
+			testCase('never', `t.pass();`),
+			testCase('never', `t.fail();`),
+			testCase('never', `t.truthy('unicorn');`),
+			testCase('never', `t.falsy('unicorn');`),
+			testCase('never', `t.true(true);`),
+			testCase('never', `t.false(false);`),
+			testCase('never', `t.is('same', 'same');`),
+			testCase('never', `t.not('not', 'same');`),
+			testCase('never', `t.deepEqual({}, {});`),
+			testCase('never', `t.notDeepEqual({}, {a: true});`),
+			testCase('never', `t.throws(Promise.reject());`),
+			testCase('never', `t.notThrows(Promise.resolve());`),
+			testCase('never', `t.regex(a, /a/);`),
+			testCase('never', `t.ifError(new Error());`),
+			testCase('never', `t.skip.is('same', 'same');`),
+			testCase('never', `t.is.skip('same', 'same');`),
+			testCase('never', `t.plan('a', 'b', 'c', 'd');`),
+			testCase('never', `t.end('a', 'b', 'c', 'd');`),
+			// shouldn't be triggered since it's not a test file
+			testCase('never', `t.true(true, 'message');`, [], false)
+		],
+		invalid: [
+			testCase('always', `t.pass();`, missingError),
+			testCase('always', `t.fail();`, missingError),
+			testCase('always', `t.truthy('unicorn');`, missingError),
+			testCase('always', `t.falsy('unicorn');`, missingError),
+			testCase('always', `t.true(true);`, missingError),
+			testCase('always', `t.false(false);`, missingError),
+			testCase('always', `t.is('same', 'same');`, missingError),
+			testCase('always', `t.not('not', 'same');`, missingError),
+			testCase('always', `t.deepEqual({}, {});`, missingError),
+			testCase('always', `t.notDeepEqual({}, {a: true});`, missingError),
+			testCase('always', `t.throws(Promise.reject());`, missingError),
+			testCase('always', `t.notThrows(Promise.resolve());`, missingError),
+			testCase('always', `t.regex(a, /a/);`, missingError),
+			testCase('always', `t.ifError(new Error());`, missingError),
+			testCase('always', `t.skip.is('same', 'same');`, missingError),
+			testCase('always', `t.is.skip('same', 'same');`, missingError),
+			testCase('always', `t.pass();`, missingError),
+
+			testCase('never', `t.pass('message');`, foundError),
+			testCase('never', `t.fail('message');`, foundError),
+			testCase('never', `t.truthy('unicorn', 'message');`, foundError),
+			testCase('never', `t.falsy('unicorn', 'message');`, foundError),
+			testCase('never', `t.true(true, 'message');`, foundError),
+			testCase('never', `t.false(false, 'message');`, foundError),
+			testCase('never', `t.is('same', 'same', 'message');`, foundError),
+			testCase('never', `t.not('not', 'same', 'message');`, foundError),
+			testCase('never', `t.deepEqual({}, {}, 'message');`, foundError),
+			testCase('never', `t.notDeepEqual({}, {a: true}, 'message');`, foundError),
+			testCase('never', `t.throws(Promise.reject(), 'message');`, foundError),
+			testCase('never', `t.notThrows(Promise.resolve(), 'message');`, foundError),
+			testCase('never', `t.regex(a, /a/, 'message');`, foundError),
+			testCase('never', `t.ifError(new Error(), 'message');`, foundError),
+			testCase('never', `t.skip.is('same', 'same', 'message');`, foundError),
+			testCase('never', `t.is.skip('same', 'same', 'message');`, foundError)
+		]
+	});
+});


### PR DESCRIPTION
Adds `assertion-message` rule (fixes #59)

Haven't added any middleground option between `always` and `never`, as I can't see any that makes sense at the moment.