### PR TITLE
use-true-false: Add framework for supporting known boolean expressions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "call-signature": "0.0.2",
     "deep-strict-equal": "^0.1.0",
+    "espree": "^3.1.3",
     "espurify": "^1.5.0",
     "multimatch": "^2.1.0",
     "object-assign": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "mocha"
   ],
   "dependencies": {
+    "call-signature": "0.0.2",
     "deep-strict-equal": "^0.1.0",
     "espurify": "^1.5.0",
     "multimatch": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "mocha"
   ],
   "dependencies": {
-    "call-signature": "0.0.2",
     "deep-strict-equal": "^0.1.0",
     "espree": "^3.1.3",
     "espurify": "^1.5.0",

--- a/rules/use-true-false.js
+++ b/rules/use-true-false.js
@@ -10,7 +10,22 @@ var booleanBinaryOperators = [
 ];
 
 var knownBooleanSignatures = [
-	'Array.isArray(x)'
+	'isFinite()',
+	'isNaN()',
+	'Object.is()',
+	'Object.isExtensible()',
+	'Object.isFrozen()',
+	'Object.isSealed()',
+	'Boolean()',
+	'Number.isNaN()',
+	'Number.isFinite()',
+	'Number.isInteger()',
+	'Number.isSafeInteger()',
+	'Array.isArray()',
+	'ArrayBuffer.isView()',
+	'SharedArrayBuffer.isView()',
+	'Reflect.has()',
+	'Reflect.isExtensible()'
 ].map(function (signature) {
 	return espurify(espree.parse(signature).body[0].expression.callee);
 });
@@ -20,11 +35,13 @@ module.exports = function (context) {
 
 	return ava.merge({
 		CallExpression: function (node) {
-			if (ava.isTestFile &&
-					ava.currentTestNode &&
-					node.callee.type === 'MemberExpression' &&
-					(node.callee.property.name === 'truthy' || node.callee.property.name === 'falsy') &&
-					util.nameOfRootObject(node.callee) === 't') {
+			if (
+				ava.isTestFile &&
+				ava.currentTestNode &&
+				node.callee.type === 'MemberExpression' &&
+				(node.callee.property.name === 'truthy' || node.callee.property.name === 'falsy') &&
+				util.nameOfRootObject(node.callee) === 't'
+			) {
 				var arg = node.arguments[0];
 
 				if (arg &&

--- a/test/use-true-false.js
+++ b/test/use-true-false.js
@@ -100,6 +100,10 @@ test(() => {
 				errors: trueErrors
 			},
 			{
+				code: testCase('t.truthy(isFinite(3))'),
+				errors: trueErrors
+			},
+			{
 				code: testCase('t.falsy(value === 1)'),
 				errors: falseErrors
 			}

--- a/test/use-true-false.js
+++ b/test/use-true-false.js
@@ -96,6 +96,10 @@ test(() => {
 				errors: trueErrors
 			},
 			{
+				code: testCase('t.truthy(Array.isArray(value))'),
+				errors: trueErrors
+			},
+			{
 				code: testCase('t.falsy(value === 1)'),
 				errors: falseErrors
 			}


### PR DESCRIPTION
Partial Fix: #79

I didn't hunt down a complete list of boolean expressions, but I have provided a framework that makes it easy to edit the list.

It uses `call-signature` (which is part of what `power-assert` uses to do some of it's magic).