### PR TITLE
Properly check for valid argument Node in use-true-false rule

### DIFF
--- a/rules/use-true-false.js
+++ b/rules/use-true-false.js
@@ -64,10 +64,10 @@ module.exports = function (context) {
 				var arg = node.arguments[0];
 
 				if (arg &&
-					(arg.type === 'BinaryExpression' && booleanBinaryOperators.indexOf(arg.operator) !== -1) ||
+					((arg.type === 'BinaryExpression' && booleanBinaryOperators.indexOf(arg.operator) !== -1) ||
 					(arg.type === 'UnaryExpression' && arg.operator === '!') ||
 					(arg.type === 'Literal' && arg.value === Boolean(arg.value)) ||
-					(matchesKnownBooleanExpression(arg))
+					(matchesKnownBooleanExpression(arg)))
 				) {
 					if (node.callee.property.name === 'falsy') {
 						context.report({

--- a/test/use-true-false.js
+++ b/test/use-true-false.js
@@ -52,6 +52,8 @@ test(() => {
 			testCase('t.falsy(value)'),
 			testCase('t.falsy(value())'),
 			testCase('t.falsy(value + value)'),
+			testCase('t.truthy()'),
+			testCase('t.falsy()'),
 			// shouldn't be triggered since it's not a test file
 			testCase('t.truthy(value === 1)', false)
 		],


### PR DESCRIPTION
This fixes a crash in Atom using `linter-xo` that happens while typing on the opening bracket of `t.truthy(` or when closing on empty argument. This check makes sure the `arg` value is completely taken into account within the check before proceeding to check any of the `||` combinations. I was getting the crash in `eslint-plugin-ava` shipped with `xo@0.14` which has different code than the master here; but I think the fix is still valid here.