### PR TITLE
Add tests for checking the index file

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint": "^2.2.0",
     "js-combinatorics": "^0.5.0",
     "nyc": "^6.4.0",
+    "pify": "^2.3.0",
     "xo": "*"
   },
   "peerDependencies": {

--- a/test/package.js
+++ b/test/package.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import test from 'ava';
+import pify from 'pify';
+import index from '../';
+
+test('Every rule is defined in index file', async t => {
+	const files = await pify(fs.readdir, Promise)('../rules/');
+	const rules = files.filter(file => file.indexOf('.js') === file.length - 3);
+
+	rules.forEach(file => {
+		const name = file.slice(0, -3);
+		t.truthy(index.rules[name], `'${name}' is not exported in 'index.js'`);
+		t.truthy(index.configs.recommended.rules[`ava/${name}`], `'${name}' is not set in the recommended config`);
+	});
+
+	t.is(Object.keys(index.rules).length, rules.length,
+		'There are more exported rules than rule files.');
+	t.is(Object.keys(index.configs.recommended.rules).length, rules.length,
+		'There are more exported rules in the recommended config than rule files.');
+});


### PR DESCRIPTION
Add tests for checking the index file

I've been bitten a few times in another my lodash-fp plugin by the fact that my `index.js` file had some typos in it (either in the exported rule, or the recommended config).

I've thus added a test to verify those.