### PR TITLE
Add `assertion-arguments` rule (fixes #92)

### DIFF
--- a/docs/rules/assertion-arguments.md
+++ b/docs/rules/assertion-arguments.md
@@ -1,0 +1,62 @@
+# Enforce passing correct arguments to assertions
+
+Enforces passing the right number of arguments to assertion methods like `t.is()`. This rule can optionally also enforce or forbid the use of assertion messages.
+
+Assertion messages are optional arguments that can be given to any assertion call to improve the error message, should the assertion fail.
+qq
+
+## Fail
+
+```js
+import test from 'ava';
+
+test(t => {
+	t.is(value); // Not enough arguments
+	t.is(value, expected, message, extra); // Too many arguments
+});
+
+/* eslint ava/assertion-arguments: ["error", {"message": "always"}] */
+test(t => {
+	t.true(array.indexOf(value) !== -1);
+});
+
+/* eslint ava/assertion-arguments: ["error", {"message": "never"}] */
+test(t => {
+	t.true(array.indexOf(value) !== -1, 'value is not in array');
+});
+```
+
+
+## Pass
+
+```js
+import test from 'ava';
+
+test(t => {
+	t.is(value, expected);
+	t.is(value, expected, message);
+});
+
+/* eslint ava/assertion-arguments: ["error", {"message": "always"}] */
+test(t => {
+	t.true(array.indexOf(value) !== -1, 'value is not in array');
+});
+
+/* eslint ava/assertion-arguments: ["error", {"message": "never"}] */
+test(t => {
+	t.true(array.indexOf(value) !== -1);
+});
+```
+
+
+## Options
+
+This rule supports the following options:
+
+`message`: A string which could be either `"always"` or `"never"`. If set to `"always"`, all assertions will need to have an assertion message. If set to `"never"`, no assertion may have an assertion message. If omitted, no reports about the assertion message will be made.
+
+You can set the option in configuration like this:
+
+```js
+"ava/assertion-arguments": ["error", {"message": "always"}]
+```

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	rules: {
+		'assertion-arguments': require('./rules/assertion-arguments'),
 		'assertion-message': require('./rules/assertion-message'),
 		'max-asserts': require('./rules/max-asserts'),
 		'no-cb-test': require('./rules/no-cb-test'),
@@ -32,6 +33,7 @@ module.exports = {
 				sourceType: 'module'
 			},
 			rules: {
+				'ava/assertion-arguments': 'error',
 				'ava/assertion-message': ['off', 'always'],
 				'ava/max-asserts': ['off', 5],
 				'ava/no-cb-test': 'off',

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ Configure it in `package.json`.
 			"ava"
 		],
 		"rules": {
+			"ava/assertion-arguments": "error",
 			"ava/assertion-message": ["off", "always"],
 			"ava/max-asserts": ["off", 5],
 			"ava/no-cb-test": "off",
@@ -60,6 +61,7 @@ Configure it in `package.json`.
 
 The rules will only activate in test files.
 
+- [assertion-arguments](docs/rules/assertion-arguments.md) - Enforce passing correct arguments to assertions.
 - [assertion-message](docs/rules/assertion-message.md) - Enforce or disallow assertion messages.
 - [max-asserts](docs/rules/max-asserts.md) - Limit the number of assertions in a test.
 - [no-cb-test](docs/rules/no-cb-test.md) - Ensure no `test.cb()` is used.

--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -1,0 +1,102 @@
+'use strict';
+var util = require('../util');
+var createAvaRule = require('../create-ava-rule');
+
+var expectedNbArguments = {
+	deepEqual: 2,
+	end: 0,
+	fail: 0,
+	false: 1,
+	falsy: 1,
+	ifError: 1,
+	is: 2,
+	not: 2,
+	notDeepEqual: 2,
+	notThrows: 1,
+	pass: 0,
+	plan: 1,
+	regex: 2,
+	throws: 1,
+	true: 1,
+	truthy: 1
+};
+
+var fixedNbArguments = {
+	end: true,
+	plan: true
+};
+
+function nbArguments(node) {
+	var name = node.property.name;
+	var nArgs = expectedNbArguments[name];
+	if (nArgs !== undefined) {
+		return {
+			min: nArgs,
+			max: fixedNbArguments[name] ? nArgs : nArgs + 1
+		};
+	}
+
+	if (node.object.type === 'MemberExpression') {
+		return nbArguments(node.object);
+	}
+
+	return false;
+}
+
+module.exports = function (context) {
+	var ava = createAvaRule();
+	var options = context.options[0] || {};
+	var enforcesMessage = Boolean(options.message);
+	var shouldHaveMessage = options.message !== 'never';
+
+	function report(node, message) {
+		context.report({
+			node: node,
+			message: message
+		});
+	}
+
+	return ava.merge({
+		CallExpression: function (node) {
+			if (!ava.isTestFile || !ava.currentTestNode || node.callee.type !== 'MemberExpression') {
+				return;
+			}
+
+			var callee = node.callee;
+			if (!callee.property || util.nameOfRootObject(callee) !== 't' || util.isInContext(callee)) {
+				return;
+			}
+
+			var gottenArgs = node.arguments.length;
+			var nArgs = nbArguments(callee);
+			if (!nArgs) {
+				return;
+			}
+
+			if (gottenArgs < nArgs.min) {
+				report(node, 'Not enough arguments. Expected at least ' + nArgs.min + '.');
+			} else if (node.arguments.length > nArgs.max) {
+				report(node, 'Too many arguments. Expected at most ' + nArgs.max + '.');
+			} else if (enforcesMessage && nArgs.min !== nArgs.max) {
+				var hasMessage = nArgs.max === gottenArgs;
+				if (!hasMessage && shouldHaveMessage) {
+					report(node, 'Expected an assertion message, but found none.');
+				} else if (hasMessage && !shouldHaveMessage) {
+					report(node, 'Expected no assertion message, but found one.');
+				}
+			}
+		}
+	});
+};
+
+module.exports.schema = [{
+	type: 'object',
+	properties: {
+		message: {
+			enum: [
+				'always',
+				'never'
+			]
+		}
+	}
+}];

--- a/test/assertion-arguments.js
+++ b/test/assertion-arguments.js
@@ -1,0 +1,205 @@
+import test from 'ava';
+import {RuleTester} from 'eslint';
+import rule from '../rules/assertion-arguments';
+
+const ruleTester = new RuleTester({
+	env: {
+		es6: true
+	}
+});
+
+const missingError = 'Expected an assertion message, but found none.';
+const foundError = 'Expected no assertion message, but found one.';
+const tooFewError = (n) => `Not enough arguments. Expected at least ${n}.`;
+const tooManyError = (n) => `Too many arguments. Expected at most ${n}.`;
+
+const header = `const test = require('ava');`;
+
+function testCase(message, content, errorMessage, useHeader) {
+	const testFn = `
+		test(t => {
+			${content}
+		});
+	`;
+
+	return {
+		errors: errorMessage && [{
+			ruleId: 'assertion-arguments',
+			message: errorMessage
+		}],
+		options: message && [{message}],
+		code: (useHeader === false ? '' : header) + testFn
+	};
+}
+
+test(() => {
+	ruleTester.run('assertion-arguments', rule, {
+		valid: [
+			testCase(false, `t.plan(1);`),
+			testCase(false, `t.end();`),
+			testCase(false, `t.deepEqual({}, {}, 'message');`),
+			testCase(false, `t.fail('message');`),
+			testCase(false, `t.false(false, 'message');`),
+			testCase(false, `t.falsy('unicorn', 'message');`),
+			testCase(false, `t.ifError(new Error(), 'message');`),
+			testCase(false, `t.is.skip('same', 'same', 'message');`),
+			testCase(false, `t.is('same', 'same', 'message');`),
+			testCase(false, `t.not('not', 'same', 'message');`),
+			testCase(false, `t.notDeepEqual({}, {a: true}, 'message');`),
+			testCase(false, `t.notThrows(Promise.resolve(), 'message');`),
+			testCase(false, `t.pass('message');`),
+			testCase(false, `t.regex(a, /a/, 'message');`),
+			testCase(false, `t.skip.is('same', 'same', 'message');`),
+			testCase(false, `t.throws(Promise.reject(), 'message');`),
+			testCase(false, `t.true(true, 'message');`),
+			testCase(false, `t.truthy('unicorn', 'message');`),
+			// shouldn't be triggered since it's not a test file
+			testCase(false, `t.true(true);`, false, false),
+
+			testCase(false, `t.deepEqual({}, {});`),
+			testCase(false, `t.fail();`),
+			testCase(false, `t.false(false);`),
+			testCase(false, `t.falsy('unicorn');`),
+			testCase(false, `t.ifError(new Error());`),
+			testCase(false, `t.is.skip('same', 'same');`),
+			testCase(false, `t.is('same', 'same');`),
+			testCase(false, `t.not('not', 'same');`),
+			testCase(false, `t.notDeepEqual({}, {a: true});`),
+			testCase(false, `t.notThrows(Promise.resolve());`),
+			testCase(false, `t.pass();`),
+			testCase(false, `t.regex(a, /a/);`),
+			testCase(false, `t.skip.is('same', 'same');`),
+			testCase(false, `t.throws(Promise.reject());`),
+			testCase(false, `t.true(true);`),
+			testCase(false, `t.truthy('unicorn');`),
+			// shouldn't be triggered since it's not a test file
+			testCase(false, `t.true(true, 'message');`, [], false),
+
+			testCase(false, `t.context.a(1, 2, 3, 4);`),
+			testCase(false, `t.context.is(1, 2, 3, 4);`),
+			testCase(false, `t.foo(1, 2, 3, 4);`),
+
+			testCase('always', `t.plan(1);`),
+			testCase('always', `t.end();`),
+			testCase('always', `t.pass('message');`),
+			testCase('always', `t.fail('message');`),
+			testCase('always', `t.truthy('unicorn', 'message');`),
+			testCase('always', `t.falsy('unicorn', 'message');`),
+			testCase('always', `t.true(true, 'message');`),
+			testCase('always', `t.false(false, 'message');`),
+			testCase('always', `t.is('same', 'same', 'message');`),
+			testCase('always', `t.not('not', 'same', 'message');`),
+			testCase('always', `t.deepEqual({}, {}, 'message');`),
+			testCase('always', `t.notDeepEqual({}, {a: true}, 'message');`),
+			testCase('always', `t.throws(Promise.reject(), 'message');`),
+			testCase('always', `t.notThrows(Promise.resolve(), 'message');`),
+			testCase('always', `t.regex(a, /a/, 'message');`),
+			testCase('always', `t.ifError(new Error(), 'message');`),
+			testCase('always', `t.skip.is('same', 'same', 'message');`),
+			testCase('always', `t.is.skip('same', 'same', 'message');`),
+			// shouldn't be triggered since it's not a test file
+			testCase('always', `t.true(true);`, [], false),
+
+			testCase('always', `t.context.a(1, 2, 3, 4);`),
+			testCase('always', `t.context.is(1, 2, 3, 4);`),
+			testCase('always', `t.foo(1, 2, 3, 4);`),
+
+			testCase('never', `t.plan(1);`),
+			testCase('never', `t.end();`),
+			testCase('never', `t.pass();`),
+			testCase('never', `t.fail();`),
+			testCase('never', `t.truthy('unicorn');`),
+			testCase('never', `t.falsy('unicorn');`),
+			testCase('never', `t.true(true);`),
+			testCase('never', `t.false(false);`),
+			testCase('never', `t.is('same', 'same');`),
+			testCase('never', `t.not('not', 'same');`),
+			testCase('never', `t.deepEqual({}, {});`),
+			testCase('never', `t.notDeepEqual({}, {a: true});`),
+			testCase('never', `t.throws(Promise.reject());`),
+			testCase('never', `t.notThrows(Promise.resolve());`),
+			testCase('never', `t.regex(a, /a/);`),
+			testCase('never', `t.ifError(new Error());`),
+			testCase('never', `t.skip.is('same', 'same');`),
+			testCase('never', `t.is.skip('same', 'same');`),
+			// shouldn't be triggered since it's not a test file
+			testCase('never', `t.true(true, 'message');`, [], false),
+
+			testCase('never', `t.context.a(1, 2, 3, 4);`),
+			testCase('never', `t.context.is(1, 2, 3, 4);`),
+			testCase('never', `t.foo(1, 2, 3, 4);`)
+		],
+		invalid: [
+			// Not enough arguments
+			testCase(false, `t.plan();`, tooFewError(1)),
+			testCase(false, `t.truthy();`, tooFewError(1)),
+			testCase(false, `t.falsy();`, tooFewError(1)),
+			testCase(false, `t.true();`, tooFewError(1)),
+			testCase(false, `t.false();`, tooFewError(1)),
+			testCase(false, `t.is('same');`, tooFewError(2)),
+			testCase(false, `t.not('not');`, tooFewError(2)),
+			testCase(false, `t.deepEqual({});`, tooFewError(2)),
+			testCase(false, `t.notDeepEqual({});`, tooFewError(2)),
+			testCase(false, `t.throws();`, tooFewError(1)),
+			testCase(false, `t.notThrows();`, tooFewError(1)),
+			testCase(false, `t.regex(a);`, tooFewError(2)),
+			testCase(false, `t.ifError();`, tooFewError(1)),
+			testCase(false, `t.skip.is('same');`, tooFewError(2)),
+			testCase(false, `t.is.skip('same');`, tooFewError(2)),
+
+			// Too many arguments
+			testCase(false, `t.plan(1, 'extra argument');`, tooManyError(1)),
+			testCase(false, `t.end('extra argument');`, tooManyError(0)),
+			testCase(false, `t.pass('message', 'extra argument');`, tooManyError(1)),
+			testCase(false, `t.fail('message', 'extra argument');`, tooManyError(1)),
+			testCase(false, `t.truthy('unicorn', 'message', 'extra argument');`, tooManyError(2)),
+			testCase(false, `t.falsy('unicorn', 'message', 'extra argument');`, tooManyError(2)),
+			testCase(false, `t.true(true, 'message', 'extra argument');`, tooManyError(2)),
+			testCase(false, `t.false(false, 'message', 'extra argument');`, tooManyError(2)),
+			testCase(false, `t.is('same', 'same', 'message', 'extra argument');`, tooManyError(3)),
+			testCase(false, `t.not('not', 'same', 'message', 'extra argument');`, tooManyError(3)),
+			testCase(false, `t.deepEqual({}, {}, 'message', 'extra argument');`, tooManyError(3)),
+			testCase(false, `t.notDeepEqual({}, {a: true}, 'message', 'extra argument');`, tooManyError(3)),
+			testCase(false, `t.throws(Promise.reject(), 'message', 'extra argument');`, tooManyError(2)),
+			testCase(false, `t.notThrows(Promise.resolve(), 'message', 'extra argument');`, tooManyError(2)),
+			testCase(false, `t.regex(a, /a/, 'message', 'extra argument');`, tooManyError(3)),
+			testCase(false, `t.ifError(new Error(), 'message', 'extra argument');`, tooManyError(2)),
+			testCase(false, `t.skip.is('same', 'same', 'message', 'extra argument');`, tooManyError(3)),
+			testCase(false, `t.is.skip('same', 'same', 'message', 'extra argument');`, tooManyError(3)),
+
+			testCase('always', `t.pass();`, missingError),
+			testCase('always', `t.fail();`, missingError),
+			testCase('always', `t.truthy('unicorn');`, missingError),
+			testCase('always', `t.falsy('unicorn');`, missingError),
+			testCase('always', `t.true(true);`, missingError),
+			testCase('always', `t.false(false);`, missingError),
+			testCase('always', `t.is('same', 'same');`, missingError),
+			testCase('always', `t.not('not', 'same');`, missingError),
+			testCase('always', `t.deepEqual({}, {});`, missingError),
+			testCase('always', `t.notDeepEqual({}, {a: true});`, missingError),
+			testCase('always', `t.throws(Promise.reject());`, missingError),
+			testCase('always', `t.notThrows(Promise.resolve());`, missingError),
+			testCase('always', `t.regex(a, /a/);`, missingError),
+			testCase('always', `t.ifError(new Error());`, missingError),
+			testCase('always', `t.skip.is('same', 'same');`, missingError),
+			testCase('always', `t.is.skip('same', 'same');`, missingError),
+
+			testCase('never', `t.pass('message');`, foundError),
+			testCase('never', `t.fail('message');`, foundError),
+			testCase('never', `t.truthy('unicorn', 'message');`, foundError),
+			testCase('never', `t.falsy('unicorn', 'message');`, foundError),
+			testCase('never', `t.true(true, 'message');`, foundError),
+			testCase('never', `t.false(false, 'message');`, foundError),
+			testCase('never', `t.is('same', 'same', 'message');`, foundError),
+			testCase('never', `t.not('not', 'same', 'message');`, foundError),
+			testCase('never', `t.deepEqual({}, {}, 'message');`, foundError),
+			testCase('never', `t.notDeepEqual({}, {a: true}, 'message');`, foundError),
+			testCase('never', `t.throws(Promise.reject(), 'message');`, foundError),
+			testCase('never', `t.notThrows(Promise.resolve(), 'message');`, foundError),
+			testCase('never', `t.regex(a, /a/, 'message');`, foundError),
+			testCase('never', `t.ifError(new Error(), 'message');`, foundError),
+			testCase('never', `t.skip.is('same', 'same', 'message');`, foundError),
+			testCase('never', `t.is.skip('same', 'same', 'message');`, foundError)
+		]
+	});
+});

--- a/util.js
+++ b/util.js
@@ -10,6 +10,14 @@ exports.nameOfRootObject = function (node) {
 	return node.object.name;
 };
 
+exports.isInContext = function (node) {
+	if (node.object.type === 'MemberExpression') {
+		return exports.isInContext(node.object);
+	}
+
+	return node.property.name === 'context';
+};
+
 exports.getAvaConfig = function (filepath) {
 	var defaultResult = {};
 	if (!filepath) {


### PR DESCRIPTION
Add `assertion-arguments` rule (fixes #92)

Willing to change the name of the rule, but this is pretty generic, and maybe some day we'll want to detect the argument types. 

Probably to be followed by the deprecation of `assertion-message`.