### PR TITLE
fix use-t rule crashing when test() has no arguments

### DIFF
--- a/rules/use-t.js
+++ b/rules/use-t.js
@@ -12,7 +12,7 @@ module.exports = function (context) {
 
 			var functionArg = node.arguments[node.arguments.length - 1];
 
-			if (!functionArg.params || !functionArg.params.length) {
+			if (!(functionArg && functionArg.params && functionArg.params.length)) {
 				return;
 			}
 

--- a/test/use-t.js
+++ b/test/use-t.js
@@ -26,6 +26,7 @@ const header = `const test = require('ava');\n`;
 test(() => {
 	ruleTester.run('use-t', rule, {
 		valid: [
+			header + 'test();',
 			header + 'test(() => {});',
 			header + 'test(t => {});',
 			header + 'test.cb(t => {});',


### PR DESCRIPTION
`use-t` rule crashes with the snippet below, which obviously is not a proper test file but it's what the linter sees if you run it as you type (with eg. the `atom` plugin)

```js
import test from 'ava'

test()
```

I've fixed it and added a test for it.