### PR TITLE
Support `always` modifier in `no-unknown-modifiers`

### DIFF
--- a/rules/no-unknown-modifiers.js
+++ b/rules/no-unknown-modifiers.js
@@ -4,6 +4,7 @@ var createAvaRule = require('../create-ava-rule');
 var modifiers = [
 	'after',
 	'afterEach',
+	'always',
 	'before',
 	'beforeEach',
 	'cb',

--- a/test/no-unknown-modifiers.js
+++ b/test/no-unknown-modifiers.js
@@ -25,6 +25,8 @@ test(() => {
 			`${header} test.serial(t => {});`,
 			`${header} test.skip(t => {});`,
 			`${header} test.todo(t => {});`,
+			`${header} test.after.always(t => {});`,
+			`${header} test.afterEach.always(t => {});`,
 			// shouldn't be triggered since it's not a test file
 			`test.foo(t => {});`
 		],


### PR DESCRIPTION
With regards to the work being done in https://github.com/sindresorhus/ava/pull/806.
Since it looked like it will be merged soon, I've prepared the work here.