### PR TITLE
Allow multiple anonymous rules in `no-identical-title`

### DIFF
--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -12,8 +12,7 @@ function isStaticTemplateLiteral(node) {
 }
 
 function isStatic(node) {
-	return !node ||
-		node.type === 'Literal' ||
+	return node.type === 'Literal' ||
 		(node.type === 'TemplateLiteral' && isStaticTemplateLiteral(node)) ||
 		(node.type === 'BinaryExpression' && isStatic(node.left) && isStatic(node.right));
 }
@@ -39,7 +38,7 @@ module.exports = function (context) {
 			var args = node.arguments;
 			var titleNode = args.length > 1 || ava.hasTestModifier('todo') ? args[0] : undefined;
 
-			if (!isStatic(titleNode)) {
+			if (titleNode === undefined || !isStatic(titleNode)) {
 				return;
 			}
 

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -38,6 +38,7 @@ module.exports = function (context) {
 			var args = node.arguments;
 			var titleNode = args.length > 1 || ava.hasTestModifier('todo') ? args[0] : undefined;
 
+			// don't flag computed titles or anonymous tests (anon tests covered in the if-multiple rule)
 			if (titleNode === undefined || !isStatic(titleNode)) {
 				return;
 			}

--- a/test/no-identical-title.js
+++ b/test/no-identical-title.js
@@ -29,6 +29,8 @@ test(() => {
 			header + 'test.beforeEach(t => {}); test.beforeEach(t => {});',
 			header + 'test.afterEach(t => {}); test.afterEach(t => {});',
 			header + 'test.cb.before(t => {}); test.before.cb(t => {});',
+			header + 'test(t => {}); test(t => {});',
+			header + 'test(t => {}); test.cb(t => {});',
 			// shouldn't be triggered since it's not a test file
 			'test(t => {}); test(t => {});',
 			'test("a", t => {}); test("a", t => {});'
@@ -40,10 +42,6 @@ test(() => {
 			},
 			{
 				code: header + 'test(`a`, t => {}); test(`a`, t => {});',
-				errors
-			},
-			{
-				code: header + 'test(t => {}); test(t => {});',
 				errors
 			},
 			{
@@ -64,10 +62,6 @@ test(() => {
 			},
 			{
 				code: header + 'test(`${"foo" + 1}`, t => {}); test(`${"foo" + 1}`, t => {});',
-				errors
-			},
-			{
-				code: header + 'test(t => {}); test.cb(t => {});',
 				errors
 			},
 			{

--- a/test/no-identical-title.js
+++ b/test/no-identical-title.js
@@ -29,6 +29,7 @@ test(() => {
 			header + 'test.beforeEach(t => {}); test.beforeEach(t => {});',
 			header + 'test.afterEach(t => {}); test.afterEach(t => {});',
 			header + 'test.cb.before(t => {}); test.before.cb(t => {});',
+			// multiple anonymous tests covered by the if-multiple rule
 			header + 'test(t => {}); test(t => {});',
 			header + 'test(t => {}); test.cb(t => {});',
 			// shouldn't be triggered since it's not a test file


### PR DESCRIPTION
Being `undefined`, I guess we can assume it's a anonymous title.